### PR TITLE
Implement Custom Error Type for make_config Function

### DIFF
--- a/chrs-lib/src/data/mod.rs
+++ b/chrs-lib/src/data/mod.rs
@@ -6,7 +6,7 @@ mod square;
 
 use crate::zobrist::{hash, update_castle, update_ep, update_side};
 use crate::{generator::MoveGenerator, zobrist::update_piece};
-use fen::Fen;
+use fen::{Fen, FenError};
 use moves::CastleType;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
@@ -41,6 +41,7 @@ pub struct BoardConfig {
 impl Default for BoardConfig {
     fn default() -> Self {
         Fen::make_config_from_str("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+            .expect("default board config is invalid")
     }
 }
 
@@ -364,12 +365,13 @@ impl BoardConfig {
         *self = BoardConfig::default();
     }
 
-    pub fn from_fen_str(s: &str) -> Self {
+    pub fn from_fen_str(s: &str) -> Result<BoardConfig, FenError> {
         Fen::make_config_from_str(s)
     }
 
-    pub fn load_fen(&mut self, s: &str) {
-        *self = Fen::make_config_from_str(s);
+    pub fn load_fen(&mut self, s: &str) -> Result<(), FenError> {
+        *self = Fen::make_config_from_str(s)?;
+        Ok(())
     }
 
     pub fn get_fen(&self) -> String {

--- a/chrs-perft/src/main.rs
+++ b/chrs-perft/src/main.rs
@@ -46,7 +46,8 @@ fn main() {
     let fen = std::env::args().nth(2).expect("Fen not provided");
     let moves = std::env::args().nth(3).unwrap_or_default();
 
-    let mut config = BoardConfig::from_fen_str(&fen);
+    let mut config = BoardConfig::from_fen_str(&fen)
+        .expect("Invalid FEN");
     let gen = MoveGenerator::default();
 
     if moves != "" {


### PR DESCRIPTION
Description:

This pull request addresses the issue of returning a custom error type from the make_config function, which is responsible for parsing a given FEN (Forsyth-Edwards Notation) string and creating a BoardConfig struct representing the game state described by the FEN string.